### PR TITLE
jestで実行するときにアクセスするポートを8080に設定した。

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: "@vue/cli-plugin-unit-jest",
-  clearMocks: true
+  clearMocks: true,
+  testURL: "http://localhost:8080"
 };

--- a/src/components/GlipahUi.vue
+++ b/src/components/GlipahUi.vue
@@ -64,7 +64,7 @@ export default {
     },
     getFunctionUrl(pageUrl) {
       const url = new URL(pageUrl);
-      if (url.hostname == "localhost") {
+      if (url.port == 8080) {
         url.port = 9000;
       }
       url.pathname = ".netlify/functions/ipaddress";


### PR DESCRIPTION

yarn run serveで起動する環境と一致させるため。